### PR TITLE
Change perceive_sentence not to include face-id for now.

### DIFF
--- a/src/ghost_bridge/perception_ctrl.py
+++ b/src/ghost_bridge/perception_ctrl.py
@@ -100,5 +100,5 @@ class PerceptionCtrl:
         :return: None
         """
 
-        content = '(ghost "{}" "{}")\n'.format(face_id, sentence)
+        content = '(ghost "{}")\n'.format(sentence)
         netcat(self.hostname, self.port, content)


### PR DESCRIPTION
For now, Ghost does not take into consideration face-id when perceiving sentences.