### PR TITLE
Remove 'ecan-based-ghost-rules' usage

### DIFF
--- a/scripts/load-opencog.scm
+++ b/scripts/load-opencog.scm
@@ -19,9 +19,7 @@
 
 (load "load-actions.scm")
 
-(ecan-based-ghost-rules #t)
 (set-relex-server-host)
-
 (start-cogserver "opencog.conf")
 (cog-logger-set-stdout! #f)
 


### PR DESCRIPTION
After https://github.com/opencog/opencog/pull/3400